### PR TITLE
updates to make jet compatible up to dj4

### DIFF
--- a/jet/__init__.py
+++ b/jet/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '1.0.8.dev2'
+VERSION = '1.0.8.dev3'

--- a/jet/dashboard/dashboard.py
+++ b/jet/dashboard/dashboard.py
@@ -7,7 +7,7 @@ except ImportError: # Django 1.11
 from django.template.loader import render_to_string
 from jet.dashboard import modules
 from jet.dashboard.models import UserDashboardModule
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from jet.ordered_set import OrderedSet
 from jet.utils import get_admin_site_name, context_to_dict
 

--- a/jet/dashboard/models.py
+++ b/jet/dashboard/models.py
@@ -1,12 +1,10 @@
 from importlib import import_module
 import json
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from jet.utils import LazyDateTimeEncoder
 
 
-@python_2_unicode_compatible
 class UserDashboardModule(models.Model):
     title = models.CharField(verbose_name=_('Title'), max_length=255)
     module = models.CharField(verbose_name=_('module'), max_length=255)

--- a/jet/dashboard/modules.py
+++ b/jet/dashboard/modules.py
@@ -3,7 +3,7 @@ from django import forms
 from django.contrib.admin.models import LogEntry
 from django.db.models import Q
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from jet.utils import get_app_list, LazyDateTimeEncoder, context_to_dict
 import datetime
 

--- a/jet/dashboard/templates/admin/index.html
+++ b/jet/dashboard/templates/admin/index.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_static jet_dashboard_tags static %}
+{% load i18n static jet_dashboard_tags static %}
 
 {% block html %}{% get_dashboard 'index' as dashboard %}{{ block.super }}{% endblock %}
 

--- a/jet/dashboard/urls.py
+++ b/jet/dashboard/urls.py
@@ -1,5 +1,5 @@
 import django
-from django.conf.urls import url
+from django.urls import re_path as url
 
 try:
     from django.views.i18n import JavaScriptCatalog

--- a/jet/dashboard/views.py
+++ b/jet/dashboard/views.py
@@ -13,7 +13,7 @@ from jet.dashboard.forms import UpdateDashboardModulesForm, AddUserDashboardModu
 from jet.dashboard.models import UserDashboardModule
 from jet.utils import JsonResponse, get_app_list, SuccessMessageMixin, user_is_authenticated
 from django.views.generic import UpdateView
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class UpdateDashboardModuleView(SuccessMessageMixin, UpdateView):

--- a/jet/models.py
+++ b/jet/models.py
@@ -1,10 +1,8 @@
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
-@python_2_unicode_compatible
 class Bookmark(models.Model):
     url = models.URLField(verbose_name=_('URL'))
     title = models.CharField(verbose_name=_('title'), max_length=255)
@@ -20,7 +18,6 @@ class Bookmark(models.Model):
         return self.title
 
 
-@python_2_unicode_compatible
 class PinnedApplication(models.Model):
     app_label = models.CharField(verbose_name=_('application name'), max_length=255)
     user = models.PositiveIntegerField(verbose_name=_('user'))

--- a/jet/ordered_set.py
+++ b/jet/ordered_set.py
@@ -1,7 +1,7 @@
-import collections
+from collections.abc import MutableSet
 
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(MutableSet):
     def __init__(self, iterable=None):
         self.end = end = []
         end += [None, end, end]         # sentinel node for doubly linked list

--- a/jet/templates/admin/edit_inline/compact.html
+++ b/jet/templates/admin/edit_inline/compact.html
@@ -1,4 +1,4 @@
-{% load i18n admin_urls admin_static %}
+{% load i18n admin_urls static %}
 
 <div class="inline-group compact" id="{{ inline_admin_formset.formset.prefix }}-group" data-inline-prefix="{{ inline_admin_formset.formset.prefix }}" data-inline-verbose-name="{{ inline_admin_formset.opts.verbose_name|capfirst }}" data-inline-delete-text="{% trans "Remove" %}">
     <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>

--- a/jet/templates/rangefilter/date_filter.html
+++ b/jet/templates/rangefilter/date_filter.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static %}
+{% load i18n static %}
 <h3>{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}</h3>
 <script>
     function datefilter_apply(event, qs_name, form_name){

--- a/jet/templatetags/jet_tags.py
+++ b/jet/templatetags/jet_tags.py
@@ -11,7 +11,7 @@ from django.forms import CheckboxInput, ModelChoiceField, Select, ModelMultipleC
 from django.contrib.admin.widgets import RelatedFieldWidgetWrapper
 from django.utils.formats import get_format
 from django.utils.safestring import mark_safe
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 from jet import settings, VERSION
 from jet.models import Bookmark
 from jet.utils import get_model_instance_label, get_model_queryset, get_possible_language_codes, \
@@ -217,7 +217,7 @@ def jet_popup_response_data(context):
     return json.dumps({
         'action': context.get('action'),
         'value': context.get('value') or context.get('pk_value'),
-        'obj': smart_text(context.get('obj')),
+        'obj': smart_str(context.get('obj')),
         'new_value': context.get('new_value')
     })
 

--- a/jet/tests/models.py
+++ b/jet/tests/models.py
@@ -1,8 +1,6 @@
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 
-@python_2_unicode_compatible
 class TestModel(models.Model):
     field1 = models.CharField(max_length=255)
     field2 = models.IntegerField()
@@ -11,7 +9,6 @@ class TestModel(models.Model):
         return '%s%d' % (self.field1, self.field2)
 
 
-@python_2_unicode_compatible
 class RelatedToTestModel(models.Model):
     field = models.ForeignKey(TestModel, on_delete=models.CASCADE)
 
@@ -19,7 +16,6 @@ class RelatedToTestModel(models.Model):
         return self.field
 
 
-@python_2_unicode_compatible
 class SearchableTestModel(models.Model):
     field1 = models.CharField(max_length=255)
     field2 = models.IntegerField()

--- a/jet/utils.py
+++ b/jet/utils.py
@@ -20,14 +20,14 @@ except ImportError: # Django 1.11
     from django.urls import reverse, resolve, NoReverseMatch
 
 from django.contrib.admin import AdminSite
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 from django.utils.text import capfirst
 from django.contrib import messages
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.functional import Promise
 from django.contrib.admin.options import IncorrectLookupParameters
 from django.contrib import admin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.utils.text import slugify
 
 try:
@@ -150,14 +150,14 @@ class LazyDateTimeEncoder(json.JSONEncoder):
         if isinstance(obj, datetime.datetime) or isinstance(obj, datetime.date):
             return obj.isoformat()
         elif isinstance(obj, Promise):
-            return force_text(obj)
+            return force_str(obj)
         return self.encode(obj)
 
 
 def get_model_instance_label(instance):
     if getattr(instance, "related_label", None):
         return instance.related_label()
-    return smart_text(instance)
+    return smart_str(instance)
 
 
 class SuccessMessageMixin(object):


### PR DESCRIPTION
forked initially from https://github.com/mailbackwards/django-jet with relevant dj3 and dj4 (as well as py3.3+) compatibility updates pieced together from https://github.com/Barukimang/django-jet

POSSIBLE SMELL:
Worth mentioning that the Barukimang fork has many try/excepts for ImportErrors, to be as kind as possible to different versions of django/python. Since we're on django@2.2 and python@3.7 and all of the imports in question are functional in those versions, I opted to just update the import itself rather than go the try block route because it keeps the code cleaner. This is assuming that our jet fork is only used in tt-docker-base where I can confirm what versions of dj and py we're on... if that's not the case, will likely want to reconsider that.